### PR TITLE
Update startmas.sh and ReadME.md in Examples folder, edit active_dali_wi.pl to reduce CPU usage

### DIFF
--- a/Examples/ReadME.md
+++ b/Examples/ReadME.md
@@ -13,7 +13,9 @@ The examples are divided into two subfolders:
 With Linux if you need to start the MAS during debug many times, you can avoid the server error, with the following command
 
     sudo sysctl net.ipv4.tcp_tw_recycle=1
-    
+
+(Note: this does not work if you have kernel version >= 4.12. See [this](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=4396e46187ca5070219b81773c4e65088dac50cc) for more information.)
+
 ### Line command editor with memory
 With Linux, Mac OS X when you start the MAS from the shell, the user agent may not have memory of the commands already sent. You can install rlwrap:
 

--- a/Examples/advanced/startmas.sh
+++ b/Examples/advanced/startmas.sh
@@ -1,28 +1,29 @@
 #exec 1>/dev/null # @echo off
 clear # cls
 #title "MAS"
-sicstus_home=/usr/local/sicstus4.2.3
+sicstus_home=/usr/local/sicstus4.3.5
+#sicstus_home=/usr/local/sicstus4.2.3
 main_home=../..
 dali_home=../../src
 conf_dir=conf
 prolog="$sicstus_home/bin/sicstus"
-WAIT="ping -c 4 127.0.0.1" 
+WAIT="ping -c 4 127.0.0.1"
 instances_home=mas/instances
 types_home=mas/types
 build_home=build
 
 rm -rf tmp/*
 rm -rf build/*
-rm -f work/*.txt # remove everything if you want to clear agent history
+rm -f work/* # remove everything if you want to clear agent history
 rm -rf conf/mas/*
 
 # Build agents by creating a file with the instance name containing the type content for each instance.
 for instance_filename in $instances_home/*.txt
-do	
+do
 	type=$(<$instance_filename) # agent type name is the content of the instance file
 	type_filename="$types_home/$type.txt"
 	instance_base="${instance_filename##*/}" # e.g. 'mas/instances/agent1.txt' -> 'agent1.txt'
-	echo $type_filename	
+	echo $type_filename
 	cat $type_filename >> "$build_home/$instance_base"
 done
 
@@ -42,7 +43,8 @@ do
 	agent_base="${agent_filename##*/}"
     echo "Agente: $agent_base"
     xterm -e "./conf/makeconf.sh $agent_base $dali_home" &
-    xterm -hold -e "./conf/startagent.sh $agent_base $prolog $dali_home" &
+    xterm -T "$agent_base" -hold -e "./conf/startagent.sh $agent_base $prolog $dali_home" &
+    sleep 2s
     $WAIT > /dev/null # %WAIT% >nul
 done
 

--- a/src/active_dali_wi.pl
+++ b/src/active_dali_wi.pl
@@ -74,7 +74,7 @@ user:term_expansion((H:at(B)),[],[],(ct(H,B)),[],[]).
   use_module(library(system)),
   use_module(library('linda/client')),
   use_module(library(clpq)),
-  
+
   use_module(library(fdbg)),
 
   use_module(library(file_systems)).
@@ -97,10 +97,10 @@ start0(FI):-set_prolog_flag(redefine_warnings,off),
             assert(specialization(Specialization)),
             if(Ontolog=no,true,load_ontology_file(Ontolog,AgentName)),
             assert(own_language(Lang)),
-            
+
             linda_client('localhost':3010),
             out(activating_agent(AgentName)),
-            
+
             delete_agent_files(File),
             token(File),
             start1(File, AgentName, Lib, Fil).
@@ -109,7 +109,7 @@ load_ontology_file(Ontolog,Agent):-
         open(Ontolog,read,Stream,[]),
         read(Stream,PrefixesC),
         read(Stream,RepositoryC),
-        read(Stream, HostC),                                                           
+        read(Stream, HostC),
         close(Stream),
         name(Repository,RepositoryC),
         name(Prefixes,PrefixesC),
@@ -121,30 +121,30 @@ filtra_fil(FI):-arg(1,FI,File),token_fil(File),retractall(parentesi(_)),togli_va
 start1(Fe,AgentName,Libr,Fil):-
   set_prolog_flag(discontiguous_warnings,off),
   if(Libr=no,true,libreria(Fe,Libr,Fil)),
-  
+
   pl_from_name(Fe, FilePl),
   ple_from_name(Fe, FilePle),
   plv_from_name(Fe, FilePlv),
   plf_from_name(Fe, FilePlf),
   txt_from_name(Fe, FileTxt),
-   
+
   aprifile(FilePl),
-  
+
   aprifile_res(FilePl),
- 
+
   carica_file(FilePl),
-  
+
   togli_var(Fe),
-  
+
   togli_var_ple(Fe),
-  
+
   if(file_exists(FilePlf), controlla_ev_all(FilePle), (inizializza_plf(FilePle), check_messaggio(FilePle, FilePlf))),
-  
+
   load_directives(FilePlf),
   server_obj(Tee), %% questo si puo togliere se si passa ad una sola funzione
   linda_client(Tee),
   assert(agente(AgentName,Tee,FilePle,FilePl)),
-  clause(specialization(Sp),_),  
+  clause(specialization(Sp),_),
   out(specialized_to(AgentName,Tee,Sp)),
   assert(agent(AgentName)),
   in_noblock(activating_agent(AgentName)),
@@ -156,7 +156,7 @@ start1(Fe,AgentName,Libr,Fil):-
   cond_esterni(FilePlv),!,
 
   asser_evN(FilePle),
-  
+
   obg_goal(FilePlv),
 
   aprifile_en(FilePl),
@@ -166,7 +166,7 @@ start1(Fe,AgentName,Libr,Fil):-
   ass_stringhe_mul(FilePlv),
 
   compile(FilePlv),
- 
+
   apri_learn(FileTxt),
   start_learn,
   manage_export_past,
@@ -207,13 +207,13 @@ versa(F):-findall(X,clause(da_agg(X),_),L),
               open(F,append,Stream,[]),nl(Stream),
               repeat,
               member(T,L),
-              write(Stream,T),write(Stream,'.'),nl(Stream), 
+              write(Stream,T),write(Stream,'.'),nl(Stream),
               T==U,!,
               close(Stream),retractall(da_agg(_)).
-   
+
 %'
-  
-aprifile(F):-see(F), 
+
+aprifile(F):-see(F),
              repeat,
                 read(T),expand_term(T,Te),
                             if(T=end_of_file,true,
@@ -227,9 +227,9 @@ take:-findall(T,clause(rule_base(T),_),L),
           last(L,U),
          repeat,
           member(M,L),
-              
+
                spezza(M),
-              
+
            M==U,!,retractall(rule_base(_)), if(clause(mul(_),_),ass_mul_first,true).
 
 
@@ -285,7 +285,7 @@ asse_cosa(C):-if(clause(C,_),true,assert(C)).
 
 discriminate_learn(Az):-functor(Az,F,_),
                 if(F=message,discriminate_learn1(Az),asse_cosa(azi(Az))).
-                                                
+
 discriminate_learn1(Az):-arg(2,Az,Pe),functor(Pe,F,_),if(F=confirm,discriminate_learn2(Pe,Az),asse_cosa(azi(Az))).
 
 discriminate_learn2(Pe,Az):-arg(1,Pe,Le),functor(Le,F,_),if(F=learn,discriminate_learn3,asse_cosa(azi(Az))).
@@ -293,7 +293,7 @@ discriminate_learn2(Pe,Az):-arg(1,Pe,Le),functor(Le,F,_),if(F=learn,discriminate
 discriminate_learn3:-assert(azi(message(_254802,confirm(learn(_254655),_254800)))).
 
 costruisci0(F):-if((((clause(even(_),_);clause(evin(_),_));clause(azi(_),_));clause(evN(_),_)),
-                     recupera_fun0(F),true).  
+                     recupera_fun0(F),true).
 recupera_fun0(F):-recupera_funE(F),recupera_funI(F),recupera_funA(F),recupera_tot_cd(F),recupera_funEn(F),recupera_gol_obt(F),recupera_gol_test(F),recupera_tot_rem(F),recupera_E(F).
 
 %ASSERISCE GLI EVENTI ESTERNI RELATIVI AGLI EVENTI MULTIPLI
@@ -424,7 +424,7 @@ recupera_fun_tes_goal(F):- name(F,L),
 recupera_tot_rem(F):-
         if(clause(fact_rem(_),_), recupera_rem(F),lista_assente(F)).
 
-recupera_rem(F):-findall(X,clause(fact_rem(X),_),Ls1), 
+recupera_rem(F):-findall(X,clause(fact_rem(X),_),Ls1),
         remove_dups(Ls1,Ls),
     name(F,L),
         append(L,[101],T),
@@ -482,7 +482,7 @@ smonta(E,F):-last(E,Ls),
                write(Stream,',number(5),last).'),
                nl(Stream),
          close(Stream),
-               
+
          Me==Ls,!.
 
 smonta_interno(E,F):- if(E=[],true,smonta_interno1(E,F)).
@@ -499,7 +499,7 @@ smonta_interno1(E,F):- name(F,Fe),
                  write(Stream,','),write(Stream,true),write(Stream,','),
                  write(Stream,'until_cond(past('),
                  write(Stream,Me), write(Stream,'))).'),nl(Stream), close(Stream),
-               
+
            Me==Ls,!.
 
 priority_azi(Fe,Ff):-leggiriga(Fe,3),
@@ -510,8 +510,8 @@ priority_azi1(L,Ff):-last(L,U),
                         member(Me,L),
                                 open(Ff,append,Stream,[]),
                                 write(Stream,'action('),write(Stream,Me),write(Stream,','),write(Stream,'normal'),
-                                write(Stream,').'),nl(Stream), 
-                                
+                                write(Stream,').'),nl(Stream),
+
                                 close(Stream),
                         Me==U,!.
 
@@ -524,14 +524,14 @@ priority_eve1(L,Ff):-last(L,U),
                                         open(Ff,append,Stream,[]),
                                         write(Stream,'external_event('),write(Stream,Me),write(Stream,','),
                                         write(Stream,'normal'),
-                                        write(Stream,').'),nl(Stream), 
-                                        
+                                        write(Stream,').'),nl(Stream),
+
                                         write(Stream,'mod('),
                                         write(Stream,Me),write(Stream,',check).'),
                                  nl(Stream),close(Stream),
                                                 Me==U,!.
 
-controlla_ev_all(F):- 
+controlla_ev_all(F):-
            leggiriga(F,2),clause(evintI(Li),_),
            leggiriga(F,3),clause(az(La),_),
            leggiriga(F,6),clause(obtgoal(Lo),_),
@@ -540,25 +540,25 @@ controlla_ev_all(F):-
            leggiriga(F,9),clause(even_args(Lg),_),
            append(Li,La,L1),append(L1,Lo,L2),append(L2,Lt,L3),
            append(L3,Lr,L4),append(L4,Lg,L6),
-          
+
                    name(F,Lista),append(Lista1,[101],Lista),
                    append(Lista1,[102],Lista3),name(Plf,Lista3),
-                                                   
+
                    see(Plf),
                         repeat,
                         read(T),
                            assert(valori_temporanei(T)),
                           T==end_of_file,
                          seen,!,
-                          
+
                           findall(X,clause(valori_temporanei(past_event(X,_)),_),Ls),
                           diff(Ls,L6,Ld1),
-                         
+
                           diff(L6,Ls,Ld2),
-                         
+
                           append(Ld1,Ld2,Ldf),
-                          
-                          if(Ldf=[], true,             
+
+                          if(Ldf=[], true,
                           (diversi_ev_all(L6),riscrivi(F,Plf))),
                           retractall(valori_temporanei(_)).
 
@@ -569,11 +569,11 @@ diversi_ev_all(L):-assert(k110055(1)),length(L,N),
                  scrivi_l124(M),
                  R is K+1,assert(k110055(R)),retractall(k110055(K)),
       K==N,!,retractall(k110055(_)).
-                                 
-                                 
+
+
 scrivi_l124(M):-if(clause(valori_temporanei(past_event(M,_)),_),true,assert(da_scrivere(M))),!.
 
-                         
+
 riscrivi(F,Plf):-
                 findall(E1,clause(da_scrivere(E1),_),Ls1),
                 if(Ls1=[],true,scrivi_da_scr(Ls1,Plf,F)).
@@ -601,7 +601,7 @@ appart_set_event(X,Plf,F):-leggiriga(F,1),clause(eventE(Le),_),
 writ_est_event(X,Plf):-open(Plf,append,Stream,[]),
                   write(Stream,'external_event('),write(Stream,X),write(Stream,','),
                   write(Stream,'normal'),
-                  write(Stream,').'),nl(Stream), 
+                  write(Stream,').'),nl(Stream),
                  write(Stream,'mod('),write(Stream,X),write(Stream,',check).'),
                  nl(Stream),close(Stream).
 
@@ -617,15 +617,15 @@ writ_actn_event(X,Plf):- functor(X,F,_),
 scr_act_mod(X,Plf):-open(Plf,append,Stream,[]),
          write(Stream,'action('),write(Stream,X),write(Stream,','),
          write(Stream,'normal'),
-         write(Stream,').'),nl(Stream),close(Stream). 
+         write(Stream,').'),nl(Stream),close(Stream).
 
 scr_msg_mod(X,Plf):-open(Plf,append,Stream,[]),
          write(Stream,'action('),write(Stream,X),write(Stream,','),
          write(Stream,'normal'),
          write(Stream,').'),nl(Stream),
          write(Stream,'mod('),write(Stream,X),write(Stream,',check).'),
-         nl(Stream),close(Stream). 
-        
+         nl(Stream),close(Stream).
+
 %DETERMINA SE UNA AZIONE (messaggio) VA SOTTOPOSTA(check) O MENO A CONTROLLO
 check_messaggio(Fe,Ff):-leggiriga(Fe,3),
            clause(az(L),_),if(L=[],true,check_mess(L,Ff)).
@@ -639,13 +639,13 @@ check_mess(L,Ff):-last(L,U),
 
 ass_plf_string(Me,Ff):-open(Ff,append,Stream,[]),
            write(Stream,'mod('),write(Stream,Me),write(Stream,','),
-           write(Stream,'check'),write(Stream,').'),nl(Stream), 
-           close(Stream). 
+           write(Stream,'check'),write(Stream,').'),nl(Stream),
+           close(Stream).
 
 %AGGIORNA LE CONDIZIONI DEGLI EVENTI ESTERNI
 writ_cond_extevent(X,Plf):-name(Plf,L),append(Li,[102],L),append(Li,[118],Lj),name(F,Lj),clause(agente(_,_,S,_),_),leggiriga(S,4),
         clause(condt(Y),true),
-        retractall(condt(_)),rip_esterni(X,Y,F).        
+        retractall(condt(_)),rip_esterni(X,Y,F).
 
 
 
@@ -660,10 +660,10 @@ load_directives(F):-open(F,read,Stream,[]),
 
 
 
-aprifile_en(F):-see(F), 
+aprifile_en(F):-see(F),
          repeat,
-        read(T), 
-                        assert(clause_man(T)), 
+        read(T),
+                        assert(clause_man(T)),
         T == end_of_file,
          !,
          seen,man_go,
@@ -686,11 +686,11 @@ man_go:-setof(X,clause_man(X),L),
         continman(X,H,A):-arg(1,X,I),if(H=en,( asse_cosa(legato_en(A,I)), write(A),nl,write(I),nl ),true).
 
 %RICEZIONE EVENTI ESTERNI%
-ricmess:-clause(agente(Ag,Ind,_,_),_),          
+ricmess:-clause(agente(Ag,Ind,_,_),_),
          if(rd_noblock(message(Ind,Ag,IndM,AgM,Language,Ontology,Con)),
          ricmess0(Ag,Ind,AgM,IndM,Language,Ontology,Con),true).
 
-                         
+
 ricmess0(Ag,Ind,AgM,IndM,Language,Ontology,Con):-
           asse_cosa(ext_agent(AgM,IndM,Ontology,Language)),
           in_noblock(message(Ind,Ag,IndM,AgM,Language,Ontology,Con)),
@@ -716,7 +716,7 @@ execute_proc(E,AgM):-clause(ext_agent(AgM,IndM,Ontology,_),_),
 execute_do_action_propose:-if(clause(do_action_propose(_,_),_),keep_action_propose1,true).
 
 keep_action_propose1:-findall(act_propose(X,Ag),
-        clause(do_action_propose(X,Ag),_),L),                  
+        clause(do_action_propose(X,Ag),_),L),
         last(L,U),
           repeat,
                    member(Me,L),
@@ -725,7 +725,7 @@ keep_action_propose1:-findall(act_propose(X,Ag),
                          if(do_propose(Az,Ag),true,
                          asse_cosa(not_executable_action_propose(Az,Ag))),
                          retractall(do_action_propose(Az,Ag)),
-                         retractall(act_propose(Az,Ag)), 
+                         retractall(act_propose(Az,Ag)),
                   Me==U,!.
 
 
@@ -743,7 +743,7 @@ not_receivable_message(AgM,IndM,Language,Ontology,Con):-write('Eliminated messag
 
 
 not_receivable_meta(AgM,IndM,Language,Ontology,Con):-write('Eliminated message:not exists meta_rule for  '),write(Con),nl,write('From:'),write(AgM),write(':'),write(IndM),nl,assert(eliminated_message(AgM,Language,Ontology,Con,motivation(not_exists_meta_rule))).
-                                                 
+
 
 
 
@@ -758,7 +758,7 @@ processa_eve_high1:-findall(ev_high(AgM,E,T),clause(ev_high(AgM,E,T),_),L),
                  member(M,L),arg(1,M,Ag),
                  arg(2,M,E),arg(3,M,T),
           if(once(eve_cond(E)),processa_eve_high(Ag,E,T),no_proc_eve_high(Ag,E,T)),
-              M==U,!. 
+              M==U,!.
 no_proc_eve_high(AgM,E,T):-write('External event preconditions not verified'),nl,retractall(ev_high(_,E,T)),asse_cosa(refused_external(AgM,E,T)).
 processa_eve_high(AgM,E,T):-retractall(ev_high(AgM,E,T)),asse_cosa(executed_external(AgM,E,T)),
 divP(E,T,program),clause(agente(_,_,S,_),_),leggiriga(S,5),
@@ -768,10 +768,10 @@ clause(evN(Es),_),if(Es=[],true,if(member(E,Es),processa_eve3(E,T),true)).
 processa_eve_normal:-if(clause(ev_normal(_,_,_),_),processa_eve_normal1,true).
 processa_eve_normal1:-clause(ev_normal(AgM,E,T),_),
                      if(once(eve_cond(E)),processa_eve_normal(AgM,E,T),no_proc_eve_normal(AgM,E,T)).
-                    
+
 no_proc_eve_normal(AgM,E,T):-write('External event preconditions not verified'),nl,retractall(ev_normal(_,E,T)),
                           asse_cosa(refused_external(AgM,E,T)).
-                  
+
 processa_eve_normal(AgM,E,T):-retractall(ev_normal(AgM,E,T)),
 divP(E,T,program),clause(agente(_,_,S,_),_),leggiriga(S,5),
 clause(evN(Es),_),if(Es=[],true,if(member(E,Es),processa_eve3(E,T),true)).
@@ -784,28 +784,28 @@ processa_eve4(Lm,X,T,Tc):-if(member(T,Lm),uccidi_iv(X,Tc),true).
 
 uccidi_iv(X,Tc):-if(clause(iv(X,Tc),_),retractall(iv(X,Tc)),true).
 
- 
 
-%LEGA LE AZIONI ALLE REGOLE AZIONI CORRISPONDENTI%              
+
+%LEGA LE AZIONI ALLE REGOLE AZIONI CORRISPONDENTI%
 azioni(Nf):-clause(agente(_,_,S,_),_),retractall(az(_)),
         leggiriga(S,3),
         clause(az(X),true),
         retractall(az(_)),if(X=[],true,azioni1(X,S,Nf)).
 azioni1(X,S,Nf):-leggiriga(S,4),
         clause(condt(Y),true),
-        retractall(condt(_)),   
+        retractall(condt(_)),
         last(X,La),
         repeat,
         member(Me,X),
         rip(Me,Y,Nf),
         Me==La.
-           
+
 rip(Me,Y,Nf):-open(Nf,append,Stream,[]),
               if(nonvar(Y),proc_rip(Me,Y,Stream),clause2(Me,Stream)),close(Stream).
 
-proc_rip(Me,Y,Stream):- 
+proc_rip(Me,Y,Stream):-
                  if(member(Me,Y),clause1(Me,Stream),clause2(Me,Stream)).
-            
+
         clause1(X,Stream):-nl(Stream),write(Stream,'a('),write(Stream,X),
                     write(Stream,'):-cd('),write(Stream,X),
                     write(Stream,'),assert(do_action('),
@@ -815,33 +815,33 @@ proc_rip(Me,Y,Stream):-
                     write(Stream,'):-cd('),write(Stream,X),
                     write(Stream,'),assert(do_action('),
                     write(Stream,X),write(Stream,',program'),write(Stream,')).'),nl(Stream),
-                    write(Stream,'cd('),write(Stream,X),write(Stream,'):-true.'). 
+                    write(Stream,'cd('),write(Stream,X),write(Stream,'):-true.').
 
 
 
-%LEGA GLI EVENTI ESTERNI ALLE REGOLE AZIONI CORRISPONDENTI% 
-             
+%LEGA GLI EVENTI ESTERNI ALLE REGOLE AZIONI CORRISPONDENTI%
+
 cond_esterni(Nf):-clause(agente(_,_,S,_),_),retractall(even_args(_)),
         leggiriga(S,9),
         clause(even_args(X),true),
         retractall(even_args(_)),if(X=[],true,cond_esterni1(X,S,Nf)).
 cond_esterni1(X,S,Nf):-leggiriga(S,4),
         clause(condt(Y),true),
-        retractall(condt(_)),   
+        retractall(condt(_)),
         last(X,La),
         repeat,
         member(Me,X),
         rip_esterni(Me,Y,Nf),
         Me==La.
-           
+
 rip_esterni(Me,Y,Nf):-open(Nf,append,Stream,[]),
               if(nonvar(Y),proc_rip_esterni(Me,Y,Stream),clause2_esterni(Me,Stream)),close(Stream).
 
 
 
-proc_rip_esterni(Me,Y,Stream):- 
+proc_rip_esterni(Me,Y,Stream):-
                  if(member(Me,Y),clause1_esterni(Me,Stream),clause2_esterni(Me,Stream)).
-            
+
         clause1_esterni(X,Stream):-nl(Stream),write(Stream,'eve_cond('),write(Stream,X),
                     write(Stream,'):-cd('),write(Stream,X),
                     write(Stream,'),eve('),
@@ -851,7 +851,7 @@ proc_rip_esterni(Me,Y,Stream):-
                     write(Stream,'):-cd('),write(Stream,X),
                     write(Stream,'),eve('),
                     write(Stream,X),write(Stream,').'),nl(Stream),
-                    write(Stream,'cd('),write(Stream,X),write(Stream,'):-true.'). 
+                    write(Stream,'cd('),write(Stream,X),write(Stream,'):-true.').
 
 %EVENTI DEL PRESENTE
 
@@ -864,11 +864,11 @@ asser_evN1(C):- last(C,La),retractall(evN(_)),
                           assert((en(Me,_):-false)),
                         Me==La,!.
 
-                                
 
 
 
-%LEGA I GOALS DA OTTENERE ALLE REGOLE GOALS CORRISPONDENTI%              
+
+%LEGA I GOALS DA OTTENERE ALLE REGOLE GOALS CORRISPONDENTI%
 obg_goal(Nf):-clause(agente(_,_,S,_),_),
         leggiriga(S,6),
         clause(obtgoal(X),true),if(X=[],true,obg_goal1(X,Nf)).
@@ -880,7 +880,7 @@ obg_goal1(X,Nf):-retractall(obtgoal(_)),
         member(Me,X),
         rip_goal(Me,Stream),
         Me==La,!,close(Stream).
-           
+
 
 rip_goal(Me,Stream):-nl(Stream),write(Stream,'obg('),
               write(Stream,Me),
@@ -898,7 +898,7 @@ asse_goal(Me):-if(clause(Me,_),true,assert(Me)).
 
 %GOALS DA TESTARE%
 tesg(X):-clause(past(X),_);clause(isa(X,_,_),_);clause(past(X,_,_),_).
- 
+
 
 %% Il do_action è asserivo nel plv quando nelle azioni.
 keep_action:-if(clause(do_action(_,_),_),keep_action1,true).
@@ -909,14 +909,14 @@ keep_action1:-findall(azione(X,Ag),clause(do_action(X,Ag),_),L),
                            member(Me,L),!,
                            arg(1,Me,Az),
                            arg(2,Me,Ag),
-                           
+
                            retractall(do_action(Az,Ag)),
                            retractall(azione(Az,Ag)),
- 
+
                            statistics(walltime,[Te,_]),
                            clause(action(Az,Mod),_),
                            if(Mod=high,assert(high_action(Az,Te,Ag)),assert(normal_action(Az,Te,Ag))),
-                                                 
+
                           Me==U,!.
 
 %SVUOTA LA CODA DELLE AZIONI AD ALTA PRIORITA'%
@@ -932,7 +932,7 @@ svuota_coda_priority1:-findall(act(X,T,Ag),clause(high_action(X,T,Ag),_),L),
                                                   retractall(high_action(Az,Te,Agt)),
                                                   fai(Az,Te,Agt),
                           Me==U,!.
-                                          
+
 
 %PRENDE UNA AZIONE DALLA CODA A  PRIORITA' NORMALE%'
 prendi_action_normal:-if(clause(normal_action(_,_,_),_),prendi_action_normal1,true).
@@ -944,8 +944,8 @@ prendi_action_normal1:-findall(act_n(X,T,Ag),clause(normal_action(X,T,Ag),_),L),
                          arg(3,Me,Agt),
                          retractall(normal_action(Az,Te,Agt)),fai(Az,Te,Agt).
 
-                          
-                                          
+
+
 
 fai(X,T,Ag):-functor(X,F,_),if(F=message,em_mess0(X,T,Ag),choose_action(X)),if(F\=message,(ver_az_int(X,T,Ag),!),true).
 
@@ -968,9 +968,9 @@ look_up_evento(X):-clause(past(X,_,_),_).
 set_past_evento(X,C):-retractall(past_event_life(X,_)),retractall(past_event_mod(X,_,_)),retractall(past_event_mod(X,_,_,_)),assert(C).
 
 
-em_mess0(X,T,Ag):-if(clause(mod(X,check),_),check_msg(X,T,Ag),em_mess(X)). 
+em_mess0(X,T,Ag):-if(clause(mod(X,check),_),check_msg(X,T,Ag),em_mess(X)).
 check_msg(X,T,Ag):-arg(1,X,To),arg(2,X,M),
-        
+
               if(call(send(To,M)),(ver_az_int(X,T,Ag),!),not_sendable_message(To,M)).
 em_mess(X):-arg(1,X,To),arg(2,X,M),send_m0(To,M).
 
@@ -1014,7 +1014,7 @@ manda_a_all(M,S,IndS):-bagof_rd_noblock(ag(A,Ind),
                           arg(2,X,IndTo),
                           out(message(IndTo,To,IndS,S,Lang,L,M)),
                           print(send_message_to(To,M,Lang,L)),nl,nl,
-           X==RL,!.   
+           X==RL,!.
 
 %%EDITONTO
 manda_a_room(M,S,IndS):-arg(2,M,Cat),functor(M,F,_),
@@ -1022,9 +1022,9 @@ manda_a_room(M,S,IndS):-arg(2,M,Cat),functor(M,F,_),
            invia_terms_ontology(L),
            clause(own_language(Lang),_),
                           out(room(F,Cat,M,IndS,S,Lang,L,C)),
-                          print(send_desire(F,Cat,M,IndS,S,Lang,L,C)),nl.         
+                          print(send_desire(F,Cat,M,IndS,S,Lang,L,C)),nl.
 
-                          
+
 ver_az_int(X,Tc,Ag):-
            divP(X,Tc,Ag),
    clause(agente(_,_,S,_),_),
@@ -1051,13 +1051,13 @@ freq_tutto1(L):-last(L,Ul),
         repeat,
         member(Me,L),
         asser_prov0(Me),
-    Me==Ul,!.  
+    Me==Ul,!.
 
 freq_sing1(L,As):-last(L,Ul),
         repeat,
         member(Me,L),
         if(member(Me,As),true,asser_prov0(Me)),
-    Me==Ul,!.  
+    Me==Ul,!.
 
 asser_prov0(Me):-if(clause(prov_int0(Me),_),true,assert(prov_int0(Me))).
 
@@ -1091,12 +1091,12 @@ passa_a_prov_int(L):-last(L,U),
               Me==U,!.
 
 
-asser_prov(Me):-if(clause(prov_int(Me),_),true,assert(prov_int(Me))).                 
-scarica_prov(Me):-if(clause(prov_int(Me),_),retractall(prov_int(Me)),true). 
+asser_prov(Me):-if(clause(prov_int(Me),_),true,assert(prov_int(Me))).
+scarica_prov(Me):-if(clause(prov_int(Me),_),retractall(prov_int(Me)),true).
 
 ev_int0:-if(clause(prov_int(_),_),ev_int01,true).
 ev_int01:-findall(M,prov_int(M),L),
-          
+
          last(L,U),
          repeat,
            member(Me,L),
@@ -1116,26 +1116,26 @@ esamina_dt(Me,C):-arg(1,C,D),arg(2,C,A),verif_time(Me,D,A).
               if((Ac=A2,A1=\=Ac),conf_date_min(Iv,D,A,C),
               if((Ac=A1,Ac=A2),
               conf_date_3(Iv,D,A,C),scarica(Iv))))).
- 
+
         conf_date_max(Iv,D,A,C):-arg(2,D,Me1),arg(3,D,G1),arg(2,C,Me),arg(3,C,G),
                        R1 is (Me1*43790+G1*1440),
                        R is (Me*43790+G*1440),
-                       
+
                        if(R>R1,controlla_ore(Iv,D,A,C),scarica(Iv)).
 
         conf_date_min(Iv,D,A,C):-arg(2,A,Me1),arg(3,A,G1),arg(2,C,Me),arg(3,C,G),
                        R2 is (Me1*43790+G1*1440),
                        R is (Me*43790+G*1440),
-                        
+
                        if(R=<R2,controlla_ore(Iv,D,A,C),scarica(Iv)).
 
-        conf_date_3(Iv,D,A,C):- 
+        conf_date_3(Iv,D,A,C):-
                 arg(2,D,Me1),arg(3,D,G1),arg(2,C,Me),arg(3,C,G),
                                    arg(2,A,Me2),arg(3,A,G2),
                                    R1 is (Me1*43790+G1*1440),
                                    R2 is (Me2*43790+G2*1440),
                                    R is (Me*43790+G*1440),
-                                   
+
                                    if((R>=R1,R=<R2),controlla_ore(Iv,D,A,C),scarica(Iv)).
 
         controlla_ore(Iv,D,A,C):-arg(4,D,H1),arg(5,D,M1),arg(6,D,S1),arg(4,A,H2),arg(5,A,M2),arg(6,A,S2),arg(4,C,H),arg(5,C,M),arg(6,C,S),
@@ -1150,7 +1150,7 @@ ora_normale(Iv,O,O1,O2):-if((O>O1,O<O2),carica(Iv),scarica(Iv)).
 
 carica(Me):-if(clause(prov_int1(Me),_),true,assert(prov_int1(Me))).
 
-scarica(Me):- 
+scarica(Me):-
 if(clause(prov_int1(Me),_),retractall(prov_int1(Me)),true).
 
 
@@ -1168,7 +1168,7 @@ blocco_numero2(L):-last(L,U),
 check_time_rep(Me,N):-functor(Me,F,_),
                       if(cond_int_repeat(F,N),check_cond_repeat(Me,N),
                       asserisco_prov_int2(Me)).
-                                          
+
 cond_int_repeat(F,N):-clause(internal_repeat(F,P),_),P>=N.
 asserisco_prov_int2(Me):-asse_cosa(prov_int2(Me)).
 
@@ -1202,9 +1202,9 @@ change_fact(M,Ti):-clause(isa(M,_,Tf),_),
 
 change_past(M,Ti):-clause(past(M,Tp,_),_),
           if(Tp>Ti,true,false).
-                                   
-                                   
-                  
+
+
+
 
 blocco_frequenza:-if(clause(prov_int2(_),_),blocco_frequenza1,true).
 blocco_frequenza1:-findall(M,clause(prov_int2(M),_),L),
@@ -1215,10 +1215,10 @@ blocco_frequenza2(L):-last(L,U),
         member(Me,L),
         if(clause(reagito(Me,_),_),true,asserisci_tempI(Me)),
          Me==U,!,retractall(prov_int2(_)).
-                 
-                 
+
+
 asserisci_tempI(Me):-
-          if(clause(tempI(Me),_),true,assert(tempI(Me))). 
+          if(clause(tempI(Me),_),true,assert(tempI(Me))).
 
 ev_int2:-if(clause(tempI(_),_),ev_intp,true).
 
@@ -1226,17 +1226,17 @@ ev_intp:-findall(Y,tempI(Y),Ls),
          statistics(walltime,[Tc,_]),
          last(Ls,La),
          repeat,
-           member(Me,Ls), 
-       if(clause(tentato_evento(Me,_),_),true,ev_int_p_no_tent(Me,Tc)),    
+           member(Me,Ls),
+       if(clause(tentato_evento(Me,_),_),true,ev_int_p_no_tent(Me,Tc)),
          Me==La,!.
-         
+
 ev_int_p_no_tent(Me,Tc):-if(once(Me),asserisci_iv(Me,Tc),retractall(tempI(Me))).
 
 asserisci_iv(Me,Tc):-assert(tentato_evento(Me,Tc)),
          if(clause(iv(Me,Tc),_),true,assert(iv(Me,Tc))),
          retractall(tempI(Me)),
          if(clause(attiva_goal(Me),_),
-         canc_goal(Me),true),    
+         canc_goal(Me),true),
          findall(X,clause(legato_en(Me,X),_),L),
          if(L=[],true,(interno_pres(Me,L),ass_ev_pre_i(Me,Tc))).
 
@@ -1252,10 +1252,10 @@ ass_ev_pre_i(Me,Tc):-setof(T,clause(lega_int_time(Me,T),_),L1),
    if(clause(ev_pre_time(Me,_,_),_),
          (retractall(ev_pre_time(Me,_,_)),assert(ev_pre_time(Me,Tc,L1))),
         assert(ev_pre_time(Me,Tc,L1))).
-                     
+
 %GESTISCE CODA GOALS DA OTTENERE%
 obtaining_goals:-findall(a(G,T),clause(ob_goal(G,T),_),Lg),if(Lg=[],true,process_ob_goal(Lg)).
-process_ob_goal(Lg):-nth0(0,Lg,Gl),arg(1,Gl,El),arg(2,Gl,T),if(once(El),fai_div_evp(El,T),true). 
+process_ob_goal(Lg):-nth0(0,Lg,Gl),arg(1,Gl,El),arg(2,Gl,T),if(once(El),fai_div_evp(El,T),true).
 fai_div_evp(El,T):-divP(El,T,program),retractall(ob_goal(El,T)).
 
 %TRATTA I GOALS DA OTTENERE COME EVENTI INTERNI
@@ -1271,7 +1271,7 @@ manage_list_int([]):-true.
 manage_list_int([A|B]):-arg(1,A,Me),arg(2,A,Tc),scat0(Me,Tc),manage_list_int(B).
 
 scat0(Me,Tc):-if(clause(legato_en(Me,_),_),scat0_en(Me,Tc),scat1(Me,Tc)).
-             
+
 scat0_en(Me,Tc):-findall(E,clause(legato_en(Me,E),_),L),
          last(L,U),
                   repeat,
@@ -1281,13 +1281,13 @@ scat0_en(Me,Tc):-findall(E,clause(legato_en(Me,E),_),L),
 
 check_app(Me,Tc,T1):-if(clause(ev_pre_time(Me,Tc,L1),_),check_member(Me,T1,Tc,L1),true).
 
-check_member(Me,T1,Tc,L1):-if(member(T1,L1),ritrai_ev_pres(Me,Tc),scat1(Me,Tc)).   
-                  
-ritrai_ev_pres(Me,Tc):-retractall(iv(Me,Tc)).                
+check_member(Me,T1,Tc,L1):-if(member(T1,L1),ritrai_ev_pres(Me,Tc),scat1(Me,Tc)).
+
+ritrai_ev_pres(Me,Tc):-retractall(iv(Me,Tc)).
 
 scat1(Me,Tc):-if(evi(Me),scatena_agisci(Me,Tc),no_scatena(Me,Tc)),!.
 no_scatena(Me,Tc):-retractall(iv(Me,Tc)),if(clause(reagito(Me,_),_),true,assert(reagito(Me,Tc))),
-                   
+
                    retractall(tempI(Me)), rec_internal_reaction(Me,Tc),
                            rec_internal_repeat(Me).
 
@@ -1299,12 +1299,12 @@ scatena_agisci(Me,Tc):-retractall(iv(Me,Tc)),divP(Me,Tc,program),
 rec_internal_reaction(Me,Tc):-functor(Me,F,_),if(clause(internal_reaction(F,_),_),
                    agg_internal_reaction(Me,Tc),crea_internal_reaction(Me,Tc)).
 
-agg_internal_reaction(Me,Tc):-functor(Me,F,_),retractall(internal_reaction(F,_)),assert(internal_reaction(F,Tc)). 
-crea_internal_reaction(Me,Tc):-functor(Me,F,_),assert(internal_reaction(F,Tc)).  
+agg_internal_reaction(Me,Tc):-functor(Me,F,_),retractall(internal_reaction(F,_)),assert(internal_reaction(F,Tc)).
+crea_internal_reaction(Me,Tc):-functor(Me,F,_),assert(internal_reaction(F,Tc)).
 
 rec_internal_repeat(Me):- functor(Me,F,_),clause(internal_repeat(F,N),_),
                   retractall(internal_repeat(F,N)),R is N+1,
-                  assert(internal_repeat(F,R)). 
+                  assert(internal_repeat(F,R)).
 
 
 controlla_freq_tent:-clause(agente(_,_,S,_),_),statistics(walltime,[T,_]),
@@ -1316,15 +1316,15 @@ contr_freq_tent0(Ls,T):-last(Ls,U),
            repeat,
            member(X,Ls),
            if(clause(internal_event(X,Tp,_,_,_),_),
-           controlla_freq_tent1(X,T,Tp),true),    
-                X==U,!.  
+           controlla_freq_tent1(X,T,Tp),true),
+                X==U,!.
 
 controlla_freq_tent1(X,T,Tp):-if(clause(tentato_evento(X,Tc),_),controlla_freq_tent2(X,T,Tp,Tc),true).
 
 controlla_freq_tent2(X,T,Tp,Tc):-Tp1 is Tp*1000,
                        ST is Tp1+Tc,
                        if(T>ST,canc_tentato(X,Tc),true).
-canc_tentato(X,Tc):-retractall(tentato_evento(X,Tc)).      
+canc_tentato(X,Tc):-retractall(tentato_evento(X,Tc)).
 
 controlla_freq_iv:-clause(agente(_,_,S,_),_),statistics(walltime,[T,_]),
                   leggiriga(S,2),clause(evintI(L),_),
@@ -1335,13 +1335,13 @@ contr_freq_iv0(Ls,T):-last(Ls,U),
            repeat,
            member(X,Ls),
            if(clause(internal_event(X,Tp,_,_,_),_),
-           controlla_freq_iv1(X,T,Tp),true),    
+           controlla_freq_iv1(X,T,Tp),true),
                 X==U,!.
-                                        
-                                        
-                                        
-                                        
-                                        
+
+
+
+
+
 controlla_freq_iv1(X,T,Tp):-if(clause(reagito(X,Tc),_),controlla_freq_int2(X,T,Tp,Tc),true).
 
 controlla_freq_int2(X,T,Tp,Tc):-Tp1 is Tp*1000,
@@ -1377,7 +1377,7 @@ controlla_vita_past2(Me,F,T):-if(F=until,processa_cd_past(Me,T),print('Writing_e
 
 processa_tempo_past(Me,T):-arg(1,Me,P),arg(2,Me,Tc),arg(3,Me,Pr),T1 is T*1000, Tt is Tc+T1,
           statistics(walltime,[Tcorr,_]),
-           
+
           if(Tt<Tcorr,processa_tempo_canc_item(P,Tc,Pr),true).
 
 processa_tempo_canc_item(Me,Tc,Pr):-retractall(past(Me)),
@@ -1416,7 +1416,7 @@ controlla_vita_remember2(Me,F,T):-if(F=until,processa_cd_remember(Me,T),print('W
 
 processa_tempo_rem(Me,T):-arg(1,Me,P),arg(2,Me,Tc),T1 is T*1000, Tt is Tc+T1,
           statistics(walltime,[Tcorr,_]),
-           
+
           if(Tt<Tcorr,processa_tempo_canc_item_rem(P,Tc),true).
 
 processa_tempo_canc_item_rem(Me,Tc):-retractall(remember(Me)),retractall(remember(Me,Tc,_)).
@@ -1433,9 +1433,9 @@ processa_cd_remember(Me,T):-arg(1,Me,P),arg(1,T,C),
 controlla_past_remember:-findall(I,clause(remember_event_mod(I,_,_),_),Is0),
                 remove_dups(Is0,Is),
                 if(Is=[],true,controlla_past_mod_rem0(Is)).
-                                        
-                                        
-                                                                                
+
+
+
 
 controlla_past_mod_rem0(Is):-last(Is,IU),
                 repeat,
@@ -1445,7 +1445,7 @@ controlla_past_mod_rem0(Is):-last(Is,IU),
                                 if(clause(remember_event_mod(Me,number(N),T1,T2),_),contrr_remember_event_event_mod3(Me,T1,T2),
                                  true))),
                   Me==IU,!.
- 
+
 contrr_remember_event_event_mod1(P,N):-findall(past_app(P,T,S),clause(remember(P,T,S),_),L0),
                  length(L0,Lu),
                   if(Lu>N,eliminate_not_last_items_remember(L0,N),true).
@@ -1488,15 +1488,15 @@ contrr_remember_event_mod3(P,T1,T2):-findall(past_app(P,T,S),clause(remember(P,T
                  arg(1,M,Pm),arg(2,M,Tm),arg(3,M,Ty),
                         if(cond_true_remember_event_mod3(T,T1,T2),true,elim_remember_event_mod3(Pm,Tm,Ty)),
            M==U,!.
-                                          
+
 elim_remember_event_mod3(Pm,Tm,Ty):-retractall(remember(Pm,Tm,Ty)).
 
 
 cond_true_remember_event_mod3(T,T1,T2):-T>=T1,T=<T2.
 
-pari:-sleep(0.2),random(1,10,R), R1 is R mod 2,
+pari:-sleep(1),random(1,10,R), R1 is R mod 2,
       if(R1=0,(internal,external),(external,internal)).
- 
+
 internal:-blocco_constr,ricmess,ev_int, ev_goal, ev_int0,blocco_numero_ev_int,blocco_frequenza,
 ev_int2,controlla_freq_tent,svuota_coda_priority,controlla_freq_iv,scatena,blocco_constr,keep_action,execute_do_action_propose,prendi_action_normal,blocco_constr,controlla_vita.
 
@@ -1514,7 +1514,7 @@ controlla_vita:-controlla_vita_past_base, controlla_vita_remember.
 
 
 
-en(X):-en(X,_). 
+en(X):-en(X,_).
 not(X):-if(X,false,true).
 
 % LIST PROCEDURE determina gli elementi di differenza tra due liste
@@ -1524,7 +1524,7 @@ diff([H|Tail],L2,[H|Tail1]):-
 not(member(H,L2)),!,
 diff(Tail,L2,Tail1).
 diff([_|Tail],L2,Tail1):-
-diff(Tail,L2,Tail1). 
+diff(Tail,L2,Tail1).
 
 
 % PRENDE LA LISTA DEI RESIDUI DEI GOALS E LA SODDISFA
@@ -1536,7 +1536,7 @@ residue_goal1:-findall(X,clause(tenta_residuo(X),_),L),
                            if(call_residue_goal(Me),resid_goal(Me),true),
           Me==U,!.
 resid_goal(Me):-retractall(tenta_residuo(Me)),if(clause(attiva_goal(Me),_),
-                   canc_goal(Me),true).       
+                   canc_goal(Me),true).
 
 % PREFISSO PAST DEi PAST%
 evp(E):-clause(past(E),_).
@@ -1576,7 +1576,7 @@ ass_stringhe_mul1(Nf,L):-open(Nf,append,Stream,[]),
 %APRE IL FILE PLV ED ASSERISCE LE REGOLE PER GLI EVENTI SINGOLI DEGLI EVENTI ESTERNI MULTIPLI
 %% e' chiamato dalla "take_meta_var" contenuta in "togli_var.pl"
 %% Il file PLV non è vuoto. Contiene cioè che è scritto nel file PL.
-aprifile_head_mul(F):-see(F), 
+aprifile_head_mul(F):-see(F),
          repeat,
         read(T),expand_term(T,Te),
                                                 if(T=end_of_file,true,
@@ -1590,7 +1590,7 @@ take_head_mul:-findall(T,clause(rule_mul_head(T),_),L),
           last(L,U),
          repeat,
           member(M,L),
-                  
+
                    arg(1,M,Head),
                    eve_mul(Head),
          M==U,!,retractall(rule_mul_head(_)), if(clause(mul(_),_),ass_mul_head,true).
@@ -1610,7 +1610,7 @@ examine_head_ass(L):-last(L,U),repeat,member(Me,L),assert(da_asserire_stringhe_m
 exist_event(X):-clause(agente(_,_,F,_),_),extern(F,X).
 
 
-   
+
 
 %LEGGE LE LISTE DEGLI EVENTI SU FILE .PLE%
 leggiriga(F,N):-see(F),read(T),if(N=1,chiudi1(T),leggiriga2(N)).
@@ -1622,9 +1622,9 @@ leggiriga(F,N):-see(F),read(T),if(N=1,chiudi1(T),leggiriga2(N)).
         leggiriga4(N):-read(T),if(N=4,chiudi4(T),leggiriga5(N)).
 
         leggiriga5(N):-read(T),if(N=5,chiudi5(T),leggiriga6(N)).
-              
+
         leggiriga6(N):-read(T),if(N=6,chiudi6(T),leggiriga7(N)).
-              
+
         leggiriga7(N):-read(T),if(N=7,chiudi7(T),leggiriga8(N)).
 
         leggiriga8(N):-read(T),if(N=8,chiudi8(T),leggiriga9).
@@ -1638,22 +1638,22 @@ leggiriga(F,N):-see(F),read(T),if(N=1,chiudi1(T),leggiriga2(N)).
         chiudi3(T):-if(clause(az(T),_),true,assert(az(T))),seen.
 
         chiudi4(T):-assert(condt(T)),seen.
-        
+
         chiudi5(T):-if(clause(evN(T),_),true,assert(evN(T))),seen.
-              
+
         chiudi6(T):-if(clause(obtgoal(T),_),true,assert(obtgoal(T))),seen.
 
         chiudi7(T):-if(clause(testgoal(T),_),true,assert(testgoal(T))),seen.
-            
+
         chiudi8(T):-if(clause(rem_fact(T),_),true,assert(rem_fact(T))),seen.
-        
+
         chiudi9(T):-if(clause(even_args(T),_),true,assert(even_args(T))),seen.
 
 
-           
-           
-    look_past_events:-findall((X,Y,T),clause(past(X,Y,T),_),L),write(L),nl.          
-             
+
+
+    look_past_events:-findall((X,Y,T),clause(past(X,Y,T),_),L),write(L),nl.
+
 
 %LEARNING
 
@@ -1682,7 +1682,7 @@ ass_learn:-assert(learn_if(_,_,_)).
 
 
 
-apri_learn(F):-see(F), 
+apri_learn(F):-see(F),
              repeat,
                 read(T),expand_term(T,Te),
                             if(T=end_of_file,true,
@@ -1700,7 +1700,7 @@ assert(txt_clause(Name,T)).
 learn_clause(H,Ag):-clause(modified_clause(H,Name),_),
                   clause(txt_clause(Name,T),_),
                   open('prova1%13%.txt',write,Stream,[]),
-            format(Stream,"'~p'.",[T]),nl(Stream),                                 
+            format(Stream,"'~p'.",[T]),nl(Stream),
             close(Stream),leggi_l(Ag).
 
 leggi_l(Ag):-clause(agent(A),_),see('prova1%13%.txt'),
@@ -1713,9 +1713,9 @@ learn_all(H,Ag):-findall(Name,clause(modified_clause(H,Name),_),LC),
           repeat,
            member(Me,LC),
                   clause(txt_clause(Me,T),_),
-                  format(Stream,"'~p'.",[T]),nl(Stream), 
-           Me==U,!,                               
-           close(Stream),leggi_all(Ag). 
+                  format(Stream,"'~p'.",[T]),nl(Stream),
+           Me==U,!,
+           close(Stream),leggi_all(Ag).
 
 leggi_all(Ag):-clause(agent(A),_),
         open('prova1%13%.txt',read,Stream,[]),
@@ -1844,37 +1844,37 @@ calcola_time_6(L,Dn):-nth1(1,L,H1),nth1(2,L,H2),nth1(3,L,M1),nth1(4,L,M2),nth1(5
           name('time(',W0),name(')',U0),append([H1],[H2],H),append(H,[44],Hv),append(Hv,[M1],HM1),
           append(HM1,[M2],HM2),append(HM2,[44],HMv),append(HMv,[S1],HMS1),
           append(HMS1,[S2],HMS2),append(W0,HMS2,P0),append(P0,U0,HMSf),name(Dn,HMSf).
-                                          
-                                          
-                                          
+
+
+
 calcola_time_5(L,Dn):-nth1(1,L,H2),nth1(2,L,M1),nth1(3,L,M2),nth1(4,L,S1),nth1(5,L,S2),
           name('time(',W0),name(')',U0),append([48],[H2],H),append(H,[44],Hv),append(Hv,[M1],HM1),
           append(HM1,[M2],HM2),append(HM2,[44],HMv),append(HMv,[S1],HMS1),
           append(HMS1,[S2],HMS2),append(W0,HMS2,P0),append(P0,U0,HMSf),name(Dn,HMSf).
-                                         
+
 calcola_time_4(L,Dn):-nth1(1,L,M1),nth1(2,L,M2),nth1(3,L,S1),nth1(4,L,S2),
           name('time(',W0),name(')',U0),append([48],[48],H),append(H,[44],Hv),append(Hv,[M1],HM1),
           append(HM1,[M2],HM2),append(HM2,[44],HMv),append(HMv,[S1],HMS1),
           append(HMS1,[S2],HMS2),append(W0,HMS2,P0),append(P0,U0,HMSf),name(Dn,HMSf).
-          
-                                          
+
+
 calcola_time_3(L,Dn):-nth1(1,L,M2),nth1(2,L,S1),nth1(3,L,S2),
           name('time(',W0),name(')',U0),append([48],[48],H),append(H,[44],Hv),append(Hv,[48],HM1),
           append(HM1,[M2],HM2),append(HM2,[44],HMv),append(HMv,[S1],HMS1),
           append(HMS1,[S2],HMS2),append(W0,HMS2,P0),append(P0,U0,HMSf),name(Dn,HMSf).
-                                          
-                                          
+
+
 calcola_time_2(L,Dn):-nth1(1,L,S1),nth1(2,L,S2),
           name('time(',W0),name(')',U0),append([48],[48],H),append(H,[44],Hv),append(Hv,[48],HM1),
           append(HM1,[48],HM2),append(HM2,[44],HMv),append(HMv,[S1],HMS1),
           append(HMS1,[S2],HMS2),append(W0,HMS2,P0),append(P0,U0,HMSf),name(Dn,HMSf).
-          
-                                         
+
+
 calcola_time_1(L,Dn):-nth1(1,L,S2),
           name('time(',W0),name(')',U0),append([48],[48],H),append(H,[44],Hv),append(Hv,[48],HM1),
           append(HM1,[48],HM2),append(HM2,[44],HMv),append(HMv,[48],HMS1),
           append(HMS1,[S2],HMS2),append(W0,HMS2,P0),append(P0,U0,HMSf),name(Dn,HMSf).
-                                                  
+
 calcola_date(D,Dn):-name(D,L),length(L,N),if(N=6,
 calcola_date_6(L,Dn),calcola_date_tree1(L,N,Dn)).
 
@@ -1896,32 +1896,32 @@ calcola_date_6(L,Dn):-nth1(1,L,H1),nth1(2,L,H2),nth1(3,L,M1),nth1(4,L,M2),nth1(5
           name('date(',W0),name(')',U0),append([H1],[H2],H),append(H,[44],Hv),append(Hv,[M1],HM1),
           append(HM1,[M2],HM2),append(HM2,[44],HMv),append(HMv,[S1],HMS1),
           append(HMS1,[S2],HMS2),append(W0,HMS2,P0),append(P0,U0,HMSf),name(Dn,HMSf).
-                                          
-                                          
-                                          
+
+
+
 calcola_date_5(L,Dn):-nth1(1,L,H2),nth1(2,L,M1),nth1(3,L,M2),nth1(4,L,S1),nth1(5,L,S2),
           name('date(',W0),name(')',U0),append([48],[H2],H),append(H,[44],Hv),append(Hv,[M1],HM1),
           append(HM1,[M2],HM2),append(HM2,[44],HMv),append(HMv,[S1],HMS1),
           append(HMS1,[S2],HMS2),append(W0,HMS2,P0),append(P0,U0,HMSf),name(Dn,HMSf).
-         
+
 calcola_date_4(L,Dn):-nth1(1,L,M1),nth1(2,L,M2),nth1(3,L,S1),nth1(4,L,S2),
           name('date(',W0),name(')',U0),append([48],[48],H),append(H,[44],Hv),append(Hv,[M1],HM1),
           append(HM1,[M2],HM2),append(HM2,[44],HMv),append(HMv,[S1],HMS1),
           append(HMS1,[S2],HMS2),append(W0,HMS2,P0),append(P0,U0,HMSf),name(Dn,HMSf).
-          
-                                          
+
+
 calcola_date_3(L,Dn):-nth1(1,L,M2),nth1(2,L,S1),nth1(3,L,S2),
           name('date(',W0),name(')',U0),append([48],[48],H),append(H,[44],Hv),append(Hv,[48],HM1),
           append(HM1,[M2],HM2),append(HM2,[44],HMv),append(HMv,[S1],HMS1),
           append(HMS1,[S2],HMS2),append(W0,HMS2,P0),append(P0,U0,HMSf),name(Dn,HMSf).
-          
-                                          
+
+
 calcola_date_2(L,Dn):-nth1(1,L,S1),nth1(2,L,S2),
           name('date(',W0),name(')',U0),append([48],[48],H),append(H,[44],Hv),append(Hv,[48],HM1),
           append(HM1,[48],HM2),append(HM2,[44],HMv),append(HMv,[S1],HMS1),
           append(HMS1,[S2],HMS2),append(W0,HMS2,P0),append(P0,U0,HMSf),name(Dn,HMSf).
-          
-                                         
+
+
 calcola_date_1(L,Dn):-nth1(1,L,S2),
           name('date(',W0),name(')',U0),append([48],[48],H),append(H,[44],Hv),append(Hv,[48],HM1),
           append(HM1,[48],HM2),append(HM2,[44],HMv),append(HMv,[48],HMS1),
@@ -1936,12 +1936,12 @@ trasform_list_in_ascii(Ln):-last(Ln,U),
                   name(Mn,Ma),
                   assert(list_ascii(Ma)),
                 Mn==U,!.
-                                          
+
 create_new_ascii_list(La):-findall(X,clause(list_ascii(X),_),La),
            retractall(list_ascii(_)).
-                                           
-                                           
-                                           
+
+
+
 ascii_in_list(La,Ln):-trasform_ascii_in_list(La),create_new_term_list(Ln).
 
 trasform_ascii_in_list(La):-last(La,U),
@@ -1950,9 +1950,9 @@ trasform_ascii_in_list(La):-last(La,U),
                   name(Tn,Ma),
                   assert(new_this_term(Tn)),
                 Ma==U,!.
-          
+
 create_new_term_list(Ln):-findall(X,clause(new_this_term(X),_),Ln),
-           retractall(new_this_term(_)). 
+           retractall(new_this_term(_)).
 
 %TRASFORMA UNA LISTA IN UNA STRINGA
 
@@ -1968,10 +1968,10 @@ parte_prima_conc_items(L,N):-repeat,
          atom_concat(X,M,M1),atom_concat(M1,',',M2),
          retractall(conc_item003(X)),
          assert(conc_item003(M2)),
-         
+
          R is K+1,assert(k_item003(R)),retractall(k_item003(K)),
          K==N,!.
-         
+
 parte_seconda(L,N,S):-nth1(N,L,M3),
          clause(conc_item003(D),_),
          atom_concat(D,M3,S),
@@ -1982,10 +1982,10 @@ parte_seconda(L,N,S):-nth1(N,L,M3),
 
 % DETERMINA L'INTERSEZIONE DI DUE LISTE
 
-intersection([],_,[]). 
-intersection([H|T],S2,[H|T3]):- member(H,S2), 
+intersection([],_,[]).
+intersection([H|T],S2,[H|T3]):- member(H,S2),
                                 intersection(T,S2,T3).
-intersection([_|T],S2,S3):-intersection(T,S2,S3).      
+intersection([_|T],S2,S3):-intersection(T,S2,S3).
 
 
 save_on_log_file(P):-clause(agent(N),_),
@@ -1994,7 +1994,7 @@ save_on_log_file(P):-clause(agent(N),_),
         open(Q,append,Stream,[]),
         write(Stream,P),nl(Stream),
         close(Stream).
-                                        
+
 % GENERA UN nUOVO AGENTE
 generate_new_agent(U):-generation_path(_,P,LO,Ont,K,Pr),create_initialization_file(U,P,LO,Ont,K),!,
 create_comm_file(U,P),create_plf_file(U,P),
@@ -2021,7 +2021,7 @@ create_initialization_file(U,P,LO,Ont,K):-
            atom_concat(B1,'.txt',B2),
            open(I2,append,Stream,[eof_action(reset)]),
            write(Stream,'agent('),
-           write(Stream,'\''),            
+           write(Stream,'\''),
            write(Stream,Y1),
            write(Stream,'\','),
            write(Stream,U),
@@ -2046,20 +2046,20 @@ create_initialization_file(U,P,LO,Ont,K):-
            write(Stream,K),
            write(Stream,').'),
            close(Stream).
-                           
-                           
+
+
 divide_host_port(L,A1,A2):-manage_host_port_list(L,A1,A2).
 manage_host_port_list([],_,A2):-findall(X,code_asc(X),L1),
                            name(A2,L1),retractall(code_asc(_)).
-                                                   
+
 manage_host_port_list([A|B],A1,A2):-A=58,findall(X,code_asc(X),L1),
                            name(A1,L1),retractall(code_asc(_)),manage_host_port_list(B,A1,A2).
-                                                   
-                                                   
+
+
 manage_host_port_list([A|B],A1,A2):-A=\=58,assert(code_asc(A)),
-                              manage_host_port_list(B,A1,A2).                                              
-                                                   
-                                                   
+                              manage_host_port_list(B,A1,A2).
+
+
 create_comm_file(U,P):-duplicate_file_comm(U,P,'communication').
 
 number_in_term(I,U,I1):-name(I,L),name(U,L1),append(L,L1,L2),name(I1,L2).
@@ -2075,7 +2075,7 @@ duplicate_file_comm(U,P,S):-
    close(Stream),
    atom_concat(P,S,S0),
    number_in_term(S0,U,S1),
-   
+
    atom_concat(S1,'.con',S2),
    open(S2,append,Stream,[]),
    findall(X,base_cod_term(X),L),append(L1,[-1],L),append(L1,[38],L2),
@@ -2086,7 +2086,7 @@ duplicate_file_comm(U,P,S):-
    M==38,!,
    close(Stream),
    retractall(base_cod_term(_)).
-                           
+
 create_plf_file(U,P):-duplicate_file_plf(U,P,'user_assistant_plf').
 
 duplicate_file_plf(U,P,S):-
@@ -2110,7 +2110,7 @@ duplicate_file_plf(U,P,S):-
    M==38,!,
    close(Stream),
    retractall(base_cod_term(_)).
-                           
+
 create_txt_file(U,P):-generation_path(NF,_,_,_,_,_),duplicate_file_txt(U,P,NF).
 
 duplicate_file_txt(U,P,S):-
@@ -2134,8 +2134,8 @@ duplicate_file_txt(U,P,S):-
    M==38,!,
    close(Stream),
    retractall(base_cod_term(_)).
-                           
-                           
+
+
 create_profile_file(U,P,Pr):-atom_concat(P,'user_profiles/profile_',S1),
            number_in_term(S1,U,S2),
            atom_concat(S2,'.txt',S3),if(file_exists(S3),true,duplicate_file_profile(U,P,Pr)).
@@ -2161,4 +2161,4 @@ duplicate_file_profile(U,P,S):-
            M==38,!,
            close(Stream),
            retractall(base_cod_term(_)).
-                           
+


### PR DESCRIPTION
Each agent window now shows the agent name in the title bar.
The ReadME gives information about why 
`sudo sysctl net.ipv4.tcp_tw_recycle=1`
does not work anymore in kernel >= 4.12.
Increased sleep from 0.2 to 1 second in active_dali_wi.pl to reduce CPU usage at run-time.